### PR TITLE
Update link of GitHub Actions build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2526S2-CS2103T-W14-1/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S2-CS2103T-W14-1/tp/actions/workflows/gradle.yml)
 
 [![codecov](https://codecov.io/github/AY2526S2-CS2103T-W14-1/tp/branch/master/graph/badge.svg?token=V1MNNPN765)](https://codecov.io/github/AY2526S2-CS2103T-W14-1/tp)
 


### PR DESCRIPTION
Fix #18 