### PR TITLE
Add tests for pet and pet fields

### DIFF
--- a/src/test/java/seedu/address/model/pet/PetNameTest.java
+++ b/src/test/java/seedu/address/model/pet/PetNameTest.java
@@ -1,4 +1,51 @@
 package seedu.address.model.pet;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 public class PetNameTest {
+
+    private static final String VALID_MAX_LENGTH_NAME = "ABCDEFGHIJKLMNO";
+    private static final String INVALID_TOO_LONG_NAME = "ABCDEFGHIJKLMNOP";
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new PetName(null));
+    }
+
+    @Test
+    public void constructor_invalidName_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new PetName(""));
+    }
+
+    @Test
+    public void isValidName() {
+        assertThrows(NullPointerException.class, () -> PetName.isValidName(null));
+
+        assertFalse(PetName.isValidName(""));
+        assertFalse(PetName.isValidName(" "));
+        assertFalse(PetName.isValidName("1Buddy"));
+        assertFalse(PetName.isValidName("Buddy!"));
+        assertFalse(PetName.isValidName(INVALID_TOO_LONG_NAME));
+
+        assertTrue(PetName.isValidName("A"));
+        assertTrue(PetName.isValidName("Buddy"));
+        assertTrue(PetName.isValidName("O'Malley"));
+        assertTrue(PetName.isValidName("Mary-Jane"));
+        assertTrue(PetName.isValidName(VALID_MAX_LENGTH_NAME));
+    }
+
+    @Test
+    public void equals() {
+        PetName petName = new PetName("Buddy");
+
+        assertTrue(petName.equals(new PetName("Buddy")));
+        assertTrue(petName.equals(petName));
+        assertFalse(petName.equals(null));
+        assertFalse(petName.equals(5));
+        assertFalse(petName.equals(new PetName("Bella")));
+    }
 }

--- a/src/test/java/seedu/address/model/pet/PetRemarkTest.java
+++ b/src/test/java/seedu/address/model/pet/PetRemarkTest.java
@@ -1,4 +1,45 @@
 package seedu.address.model.pet;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 public class PetRemarkTest {
+
+    private static final String VALID_MAX_LENGTH_REMARK = "a".repeat(PetRemark.MAX_LENGTH);
+    private static final String INVALID_TOO_LONG_REMARK = "a".repeat(PetRemark.MAX_LENGTH + 1);
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new PetRemark(null));
+    }
+
+    @Test
+    public void constructor_invalidRemark_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new PetRemark(INVALID_TOO_LONG_REMARK));
+    }
+
+    @Test
+    public void isValidRemark() {
+        assertThrows(NullPointerException.class, () -> PetRemark.isValidRemark(null));
+
+        assertTrue(PetRemark.isValidRemark(""));
+        assertTrue(PetRemark.isValidRemark("Friendly and energetic"));
+        assertTrue(PetRemark.isValidRemark(VALID_MAX_LENGTH_REMARK));
+
+        assertFalse(PetRemark.isValidRemark(INVALID_TOO_LONG_REMARK));
+    }
+
+    @Test
+    public void equals() {
+        PetRemark petRemark = new PetRemark("Loves treats");
+
+        assertTrue(petRemark.equals(new PetRemark("Loves treats")));
+        assertTrue(petRemark.equals(petRemark));
+        assertFalse(petRemark.equals(null));
+        assertFalse(petRemark.equals(5));
+        assertFalse(petRemark.equals(new PetRemark("Needs extra care")));
+    }
 }

--- a/src/test/java/seedu/address/model/pet/PetTest.java
+++ b/src/test/java/seedu/address/model/pet/PetTest.java
@@ -1,4 +1,90 @@
 package seedu.address.model.pet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.session.Session;
+
 public class PetTest {
+
+    private static final PetName VALID_NAME = new PetName("Buddy");
+    private static final Species VALID_SPECIES = new Species("Dog");
+    private static final PetRemark VALID_REMARK = new PetRemark("Friendly");
+
+    @Test
+    public void constructor_nullFields_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Pet(null, VALID_SPECIES, VALID_REMARK));
+        assertThrows(NullPointerException.class, () -> new Pet(VALID_NAME, null, VALID_REMARK));
+        assertThrows(NullPointerException.class, () -> new Pet(VALID_NAME, VALID_SPECIES, null));
+    }
+
+    @Test
+    public void isSamePet() {
+        Pet pet = new Pet(VALID_NAME, VALID_SPECIES, VALID_REMARK);
+
+        assertTrue(pet.isSamePet(pet));
+        assertFalse(pet.isSamePet(null));
+        assertTrue(pet.isSamePet(new Pet(new PetName("Buddy"), new Species("Dog"), new PetRemark("Needs medication"))));
+        assertFalse(pet.isSamePet(new Pet(new PetName("Bella"), new Species("Dog"), VALID_REMARK)));
+        assertFalse(pet.isSamePet(new Pet(new PetName("Buddy"), new Species("Cat"), VALID_REMARK)));
+    }
+
+    @Test
+    public void updateRemark() {
+        Pet pet = new Pet(VALID_NAME, VALID_SPECIES, VALID_REMARK);
+
+        pet.updateRemark("Needs medication");
+        assertEquals(new PetRemark("Needs medication"), pet.getRemark());
+
+        pet.updateRemark("");
+        assertEquals(new PetRemark(""), pet.getRemark());
+    }
+
+    @Test
+    public void sessions() {
+        Pet pet = new Pet(VALID_NAME, VALID_SPECIES, VALID_REMARK);
+        Session session = new Session("2026-04-06 10:00", "2026-04-06 11:00", 25.0);
+
+        assertTrue(pet.getSessions().isEmpty());
+
+        pet.addSession(session);
+        assertEquals(List.of(session), pet.getSessions());
+        assertThrows(UnsupportedOperationException.class, () -> pet.getSessions().add(session));
+        assertThrows(NullPointerException.class, () -> pet.addSession(null));
+    }
+
+    @Test
+    public void equals() {
+        Pet pet = new Pet(VALID_NAME, VALID_SPECIES, VALID_REMARK);
+        Pet samePet = new Pet(new PetName("Buddy"), new Species("Dog"), new PetRemark("Friendly"));
+        Pet differentRemarkPet = new Pet(new PetName("Buddy"), new Species("Dog"), new PetRemark("Needs medication"));
+        Pet differentNamePet = new Pet(new PetName("Bella"), new Species("Dog"), VALID_REMARK);
+        Pet differentSpeciesPet = new Pet(new PetName("Buddy"), new Species("Cat"), VALID_REMARK);
+
+        assertTrue(pet.equals(samePet));
+        assertEquals(pet.hashCode(), samePet.hashCode());
+        assertTrue(pet.equals(pet));
+        assertFalse(pet.equals(null));
+        assertFalse(pet.equals(5));
+        assertFalse(pet.equals(differentRemarkPet));
+        assertFalse(pet.equals(differentNamePet));
+        assertFalse(pet.equals(differentSpeciesPet));
+    }
+
+    @Test
+    public void equals_sessionsDiffer_stillEqual() {
+        Pet pet = new Pet(VALID_NAME, VALID_SPECIES, VALID_REMARK);
+        Pet samePetWithoutSessions = new Pet(new PetName("Buddy"), new Species("Dog"), new PetRemark("Friendly"));
+
+        pet.addSession(new Session("2026-04-06 10:00", "2026-04-06 11:00", 25.0));
+
+        assertTrue(pet.equals(samePetWithoutSessions));
+        assertEquals(pet.hashCode(), samePetWithoutSessions.hashCode());
+    }
 }

--- a/src/test/java/seedu/address/model/pet/SpeciesTest.java
+++ b/src/test/java/seedu/address/model/pet/SpeciesTest.java
@@ -1,4 +1,50 @@
 package seedu.address.model.pet;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 public class SpeciesTest {
+
+    private static final String VALID_MAX_LENGTH_SPECIES = "ABCDEFGHIJKLMNO";
+    private static final String INVALID_TOO_LONG_SPECIES = "ABCDEFGHIJKLMNOP";
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Species(null));
+    }
+
+    @Test
+    public void constructor_invalidSpecies_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new Species(""));
+    }
+
+    @Test
+    public void isValidSpecies() {
+        assertThrows(NullPointerException.class, () -> Species.isValidSpecies(null));
+
+        assertFalse(Species.isValidSpecies(""));
+        assertFalse(Species.isValidSpecies(" "));
+        assertFalse(Species.isValidSpecies("Cat-1"));
+        assertFalse(Species.isValidSpecies("Golden_Retriever"));
+        assertFalse(Species.isValidSpecies(INVALID_TOO_LONG_SPECIES));
+
+        assertTrue(Species.isValidSpecies("C"));
+        assertTrue(Species.isValidSpecies("Dog"));
+        assertTrue(Species.isValidSpecies("Sea Lion"));
+        assertTrue(Species.isValidSpecies(VALID_MAX_LENGTH_SPECIES));
+    }
+
+    @Test
+    public void equals() {
+        Species species = new Species("Dog");
+
+        assertTrue(species.equals(new Species("Dog")));
+        assertTrue(species.equals(species));
+        assertFalse(species.equals(null));
+        assertFalse(species.equals(5));
+        assertFalse(species.equals(new Species("Cat")));
+    }
 }


### PR DESCRIPTION
Fixes #156.

The partitions covered are:

  - PetName
      - null constructor input
      - invalid names: empty, spaces-only, non-letter first char, disallowed punctuation, over max length
      - valid names: min boundary length 1, normal alphabetic, apostrophe, hyphen, max boundary length 15
      - value equality behavior
  - Species
      - null constructor input
      - invalid species: empty, spaces-only, disallowed non-space punctuation/digits, over max length
      - valid species: min boundary length 1, normal alphabetic, internal spaces, max boundary length 15
      - value equality behavior
  - PetRemark
      - null constructor input
      - invalid remark: length 301
      - valid remark: empty string, typical short text, max boundary length 300
      - value equality behavior
  - Pet
      - constructor null-field rejection for each field
      - isSamePet partitions: same object, null, same identity with different remark, different name, different species
      - updateRemark with non-empty and empty valid remarks
      - session behavior: initially empty, add session, returned list unmodifiable, null session rejected
      - equals/hashCode: same values, different remark, different name, different species, null, different type
      - current codebase-specific invariant: differing session lists do not affect equality
