### PR TITLE
Update session list after adding owner

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
@@ -59,6 +59,7 @@ public class AddOwnerCommand extends Command {
         }
 
         model.addPerson(toAdd);
+        model.updateDisplayedSessions(model.getFilteredPersonList());
         String messageTemplate = toAdd.getPhone().hasOnlyDigits()
                 ? MESSAGE_SUCCESS
                 : MESSAGE_SUCCESS_WITH_PHONE_WARNING;


### PR DESCRIPTION
Fix #269
Now after adding an owner, the session list will follow the behaviour of owner list and sets to default, so that no faulty deletion would happen.

<img width="2563" height="1603" alt="image" src="https://github.com/user-attachments/assets/554f3aaf-e617-4184-8b6a-f2de5e2b8088" />
