### PR TITLE
Update view after addowner, editowner

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -109,6 +109,7 @@ Format: `addowner on/OWNER_NAME ph/PHONE_NUMBER em/EMAIL ad/ADDRESS [ot/TAG]…�
   The `domain` must be 2 to 30 characters long. Each domain label must start and end with an alphanumeric character, and may contain hyphens only in the middle. The final domain label must be at least 2 characters long.
 * `ADDRESS` must be 1 to 100 characters.
 * Each `TAG`, if provided, must be 1 to 20 characters.
+* Upon successful addition of an owner, PetLog will display all owners (as if [`list`](#listing-all-owners-list) was run) and automatically scroll to the bottom of the list for you to see the newly added owner.
 
 Examples:
 * `addowner on/John Doe ph/98765432 em/johnd@example.com ad/John street, block 123, #01-01`
@@ -212,7 +213,7 @@ Examples:
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 Use `list` after using [`find`](#searching-for-owners-find) to go back to displaying all owners.
-Successfully [adding an owner](#adding-an-owner-addowner) will also reset the view and display all owners, allowing you to see the newly added owner.
+Successfully [adding an owner](#adding-an-owner-addowner) will also reset the view and display all owners.
 </div>
 
 [↑ Back to ToC](UserGuide.md)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -194,7 +194,7 @@ Examples:
 
 ### Searching for owners: `find`
 
-Finds owners whose details match at least one of the given keywords.
+Displays owners whose details match at least one of the given keywords.
 
 Format: `find [on/OWNER_NAME] [ph/PHONE_NUMBER] [em/EMAIL] [ad/ADDRESS] [ot/OWNER_TAG]…​ [pn/PET_NAME] [ps/SPECIES] [pr/REMARKS]`
 
@@ -210,19 +210,20 @@ Examples:
 * `find ad/Tampines ot/VIP` returns owners whose address contains `Tampines` OR who are tagged as `VIP`s _(screenshot cropped to show relevant UI elements)_:
 ![[result for 'find ad/Tampines ot/VIP']](images/findAdTampinesOtVip.png)
 
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+Use `list` after using [`find`](#searching-for-owners-find) to go back to displaying all owners.
+Successfully [adding an owner](#adding-an-owner-addowner) will also reset the view and display all owners, allowing you to see the newly added owner.
+</div>
+
 [↑ Back to ToC](UserGuide.md)
 
 <div style="page-break-after: always;"></div>
 
 ### Listing all owners: `list`
 
-Shows a list of all owners and pets in PetLog.
+Shows all owners, pets and sessions in PetLog.
 
 Format: `list`
-
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-Use `list` after using [`find`](#searching-for-owners-find) to go back to displaying all owners and pets.
-</div>
 
 [↑ Back to ToC](UserGuide.md)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -212,7 +212,7 @@ Examples:
 ![[result for 'find ad/Tampines ot/VIP']](images/findAdTampinesOtVip.png)
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-Use `list` after using [`find`](#searching-for-owners-find) to go back to displaying all owners.
+Use `list` after using [`find`](#searching-for-owners-find) return to the list of all owners.
 Successfully [adding an owner](#adding-an-owner-addowner) will also reset the view and display all owners.
 </div>
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_OWNER_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMOVE_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -95,7 +94,6 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.updateDisplayedSessions(model.getFilteredPersonList());
         String messageTemplate = editedPerson.getPhone().hasOnlyDigits()
             ? MESSAGE_EDIT_PERSON_SUCCESS

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -205,6 +205,10 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
+            if (isAddOwnerCommand(commandText) && ownerListPanel != null) {
+                Platform.runLater(ownerListPanel::scrollToLastOwner);
+            }
+
             if (commandResult.isShowHelp()) {
                 handleHelp();
             }
@@ -219,5 +223,14 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;
         }
+    }
+
+    private static boolean isAddOwnerCommand(String commandText) {
+        String trimmedCommand = commandText.trim();
+        if (trimmedCommand.isEmpty()) {
+            return false;
+        }
+        String commandWord = trimmedCommand.split("\\s+", 2)[0];
+        return commandWord.equals("addowner");
     }
 }

--- a/src/main/java/seedu/address/ui/OwnerListPanel.java
+++ b/src/main/java/seedu/address/ui/OwnerListPanel.java
@@ -27,6 +27,16 @@ public class OwnerListPanel extends UiPart<Region> {
     }
 
     /**
+     * Scrolls the owner list to the final row if the list is non-empty.
+     */
+    public void scrollToLastOwner() {
+        int lastOwnerIndex = personListView.getItems().size() - 1;
+        if (lastOwnerIndex >= 0) {
+            personListView.scrollTo(lastOwnerIndex);
+        }
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code OwnerCard}.
      */
     class OwnerListViewCell extends ListCell<Person> {

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -103,7 +103,8 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        expectedModel.setPerson(expectedModel.getFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Make it so `editowner` after `find` does not reset the filtered view. `addowner` does reset the filtered view and scrolls to the bottom of the list for users to see the newly added user. 