### PR TITLE
Improve owner duplicate detection and add partial-match warnings

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
@@ -64,23 +64,40 @@ public class AddOwnerCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd)) {
+        boolean isFullDuplicate = model.getAddressBook().getPersonList().stream()
+                .anyMatch(existing -> existing.getMatchingIdentityFields(toAdd).size() == 4);
+
+        if (isFullDuplicate) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
         Set<String> matchedFields = collectPartialMatchFields(model);
         model.addPerson(toAdd);
 
-        StringBuilder feedback = new StringBuilder(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+        boolean hasPhoneWarning = !toAdd.getPhone().hasOnlyDigits();
+        boolean hasPartialWarning = !matchedFields.isEmpty();
 
-        if (!toAdd.getPhone().hasOnlyDigits()) {
-            appendWarning(feedback, MESSAGE_PHONE_WARNING);
+        String message;
+
+        if (hasPhoneWarning && !hasPartialWarning) {
+            message = String.format(MESSAGE_SUCCESS_WITH_PHONE_WARNING, Messages.format(toAdd));
+        } else if (!hasPhoneWarning && hasPartialWarning) {
+            message = String.format(MESSAGE_SUCCESS, Messages.format(toAdd))
+                    + "\n"
+                    + String.format(MESSAGE_PARTIAL_DUPLICATE_WARNING,
+                    formatMatchedFields(matchedFields));
+        } else if (hasPhoneWarning && hasPartialWarning) {
+            message = String.format(MESSAGE_SUCCESS, Messages.format(toAdd))
+                    + "\n"
+                    + MESSAGE_PHONE_WARNING
+                    + "\n"
+                    + String.format(MESSAGE_PARTIAL_DUPLICATE_WARNING,
+                    formatMatchedFields(matchedFields));
+        } else {
+            message = String.format(MESSAGE_SUCCESS, Messages.format(toAdd));
         }
-        if (!matchedFields.isEmpty()) {
-            appendWarning(feedback, String.format(MESSAGE_PARTIAL_DUPLICATE_WARNING,
-                    formatMatchedFields(matchedFields)));
-        }
-        return new CommandResult(feedback.toString());
+
+        return new CommandResult(message);
     }
 
     private Set<String> collectPartialMatchFields(Model model) {
@@ -89,7 +106,7 @@ public class AddOwnerCommand extends Command {
         for (Person existingPerson : model.getAddressBook().getPersonList()) {
             List<String> matchingFields = existingPerson.getMatchingIdentityFields(toAdd);
 
-            if (!matchingFields.isEmpty() && matchingFields.size() < NUMBER_OF_IDENTITY_FIELDS) {
+            if (matchingFields.size() >= 2 && matchingFields.size() < NUMBER_OF_IDENTITY_FIELDS) {
                 matchedFields.addAll(matchingFields);
             }
         }

--- a/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_OWNER_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -79,7 +80,7 @@ public class AddOwnerCommand extends Command {
             appendWarning(feedback, String.format(MESSAGE_PARTIAL_DUPLICATE_WARNING,
                     formatMatchedFields(matchedFields)));
         }
-        return new CommandResult(String.format(feedback.toString()));
+        return new CommandResult(feedback.toString());
     }
 
     private Set<String> collectPartialMatchFields(Model model) {
@@ -101,17 +102,30 @@ public class AddOwnerCommand extends Command {
     }
 
     private String formatMatchedFields(Set<String> matchedFields) {
-        List<String> fields = List.copyOf(matchedFields);
+        List<String> ordered = new ArrayList<>();
 
-        if (fields.size() == 1) {
-            return fields.get(0);
+        if (matchedFields.contains("name")) {
+            ordered.add("name");
         }
-        if (fields.size() == 2) {
-            return fields.get(0) + " and " + fields.get(1);
+        if (matchedFields.contains("phone")) {
+            ordered.add("phone");
+        }
+        if (matchedFields.contains("email")) {
+            ordered.add("email");
+        }
+        if (matchedFields.contains("address")) {
+            ordered.add("address");
         }
 
-        String allButLast = String.join(", ", fields.subList(0, fields.size() - 1));
-        return allButLast + ", and " + fields.get(fields.size() - 1);
+        if (ordered.size() == 1) {
+            return ordered.get(0);
+        }
+        if (ordered.size() == 2) {
+            return ordered.get(0) + " and " + ordered.get(1);
+        }
+
+        String allButLast = String.join(", ", ordered.subList(0, ordered.size() - 1));
+        return allButLast + ", and " + ordered.get(ordered.size() - 1);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOwnerCommand.java
@@ -7,6 +7,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_OWNER_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -36,9 +40,14 @@ public class AddOwnerCommand extends Command {
             + PREFIX_TAG + "VIP";
 
     public static final String MESSAGE_SUCCESS = "Added owner: %1$s";
+    public static final String MESSAGE_PHONE_WARNING =
+            "Warning: Phone contains non-numeric characters. Use editowner to amend if necessary.";
     public static final String MESSAGE_SUCCESS_WITH_PHONE_WARNING = "Added owner: %1$s\n"
             + "Warning: Phone contains non-numeric characters. Use editowner to amend if necessary.";
+    public static final String MESSAGE_PARTIAL_DUPLICATE_WARNING =
+            "Warning: %1$s match existing owner records. Use editowner to amend if necessary.";
     public static final String MESSAGE_DUPLICATE_PERSON = "Owner already exists.";
+    private static final int NUMBER_OF_IDENTITY_FIELDS = 4;
 
     private final Person toAdd;
 
@@ -58,11 +67,51 @@ public class AddOwnerCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        Set<String> matchedFields = collectPartialMatchFields(model);
         model.addPerson(toAdd);
-        String messageTemplate = toAdd.getPhone().hasOnlyDigits()
-                ? MESSAGE_SUCCESS
-                : MESSAGE_SUCCESS_WITH_PHONE_WARNING;
-        return new CommandResult(String.format(messageTemplate, Messages.format(toAdd)));
+
+        StringBuilder feedback = new StringBuilder(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+
+        if (!toAdd.getPhone().hasOnlyDigits()) {
+            appendWarning(feedback, MESSAGE_PHONE_WARNING);
+        }
+        if (!matchedFields.isEmpty()) {
+            appendWarning(feedback, String.format(MESSAGE_PARTIAL_DUPLICATE_WARNING,
+                    formatMatchedFields(matchedFields)));
+        }
+        return new CommandResult(String.format(feedback.toString()));
+    }
+
+    private Set<String> collectPartialMatchFields(Model model) {
+        Set<String> matchedFields = new LinkedHashSet<>();
+
+        for (Person existingPerson : model.getAddressBook().getPersonList()) {
+            List<String> matchingFields = existingPerson.getMatchingIdentityFields(toAdd);
+
+            if (!matchingFields.isEmpty() && matchingFields.size() < NUMBER_OF_IDENTITY_FIELDS) {
+                matchedFields.addAll(matchingFields);
+            }
+        }
+
+        return matchedFields;
+    }
+
+    private void appendWarning(StringBuilder feedback, String warning) {
+        feedback.append("\n").append(warning);
+    }
+
+    private String formatMatchedFields(Set<String> matchedFields) {
+        List<String> fields = List.copyOf(matchedFields);
+
+        if (fields.size() == 1) {
+            return fields.get(0);
+        }
+        if (fields.size() == 2) {
+            return fields.get(0) + " and " + fields.get(1);
+        }
+
+        String allButLast = String.join(", ", fields.subList(0, fields.size() - 1));
+        return allButLast + ", and " + fields.get(fields.size() - 1);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,7 +2,6 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.commons.util.StringUtil.normalizeForComparison;
-import static seedu.address.commons.util.StringUtil.normalizeWhitespace;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -142,8 +141,6 @@ public class Person {
         return otherPerson != null
                 && normalizeName(otherPerson.getName()).equals(normalizeName(getName()))
                 && normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()));
-                // && normalizeEmail(otherPerson.getEmail()).equals(normalizeEmail(getEmail()))
-                // && normalizeAddress(otherPerson.getAddress()).equals(normalizeAddress(getAddress()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -144,12 +144,45 @@ public class Person {
                 && normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()));
     }
 
+    /**
+     * Returns the owner identity fields that match between this person and {@code otherPerson}
+     * after normalisation, in the order name, phone, email, address.
+     */
+    public List<String> getMatchingIdentityFields(Person otherPerson) {
+        requireAllNonNull(otherPerson);
+
+        List<String> matchingFields = new ArrayList<>();
+
+        if (normalizeName(otherPerson.getName()).equals(normalizeName(getName()))) {
+            matchingFields.add("name");
+        }
+        if (normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()))) {
+            matchingFields.add("phone");
+        }
+        if (normalizeEmail(otherPerson.getEmail()).equals(normalizeEmail(getEmail()))) {
+            matchingFields.add("email");
+        }
+        if (normalizeAddress(otherPerson.getAddress()).equals(normalizeAddress(getAddress()))) {
+            matchingFields.add("address");
+        }
+
+        return Collections.unmodifiableList(matchingFields);
+    }
+
     private String normalizeName(Name name) {
         return normalizeForComparison(name.fullName);
     }
 
     private String normalizePhone(Phone phone) {
         return normalizeWhitespace(phone.value);
+    }
+
+    private String normalizeEmail(Email email) {
+        return normalizeForComparison(email.value);
+    }
+
+    private String normalizeAddress(Address address) {
+        return normalizeForComparison(address.value);
     }
 
     private String normalizePetName(Pet pet) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -141,7 +141,9 @@ public class Person {
 
         return otherPerson != null
                 && normalizeName(otherPerson.getName()).equals(normalizeName(getName()))
-                && normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()));
+                && normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()))
+                && normalizeEmail(otherPerson.getEmail()).equals(normalizeEmail(getEmail()))
+                && normalizeAddress(otherPerson.getAddress()).equals(normalizeAddress(getAddress()));
     }
 
     /**
@@ -174,7 +176,7 @@ public class Person {
     }
 
     private String normalizePhone(Phone phone) {
-        return normalizeWhitespace(phone.value);
+        return phone.value.replaceAll("[^0-9]", "");
     }
 
     private String normalizeEmail(Email email) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -141,9 +141,9 @@ public class Person {
 
         return otherPerson != null
                 && normalizeName(otherPerson.getName()).equals(normalizeName(getName()))
-                && normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()))
-                && normalizeEmail(otherPerson.getEmail()).equals(normalizeEmail(getEmail()))
-                && normalizeAddress(otherPerson.getAddress()).equals(normalizeAddress(getAddress()));
+                && normalizePhone(otherPerson.getPhone()).equals(normalizePhone(getPhone()));
+                // && normalizeEmail(otherPerson.getEmail()).equals(normalizeEmail(getEmail()))
+                // && normalizeAddress(otherPerson.getAddress()).equals(normalizeAddress(getAddress()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -42,7 +42,10 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public void add(Person toAdd) {
         requireNonNull(toAdd);
-        if (contains(toAdd)) {
+        boolean isFullDuplicate = internalList.stream()
+                .anyMatch(existing -> existing.getMatchingIdentityFields(toAdd).size() == 4);
+
+        if (isFullDuplicate) {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);

--- a/src/test/java/seedu/address/logic/commands/AddOwnerCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOwnerCommandIntegrationTest.java
@@ -58,14 +58,22 @@ public class AddOwnerCommandIntegrationTest {
     }
 
     @Test
-    public void execute_sameNameIgnoringCaseAndSamePhone_throwsCommandException() {
+    public void execute_sameNameIgnoringCaseAndSamePhoneDifferentEmailAndAddress_successWithWarning() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        Person duplicatePerson = new PersonBuilder(personInList)
+        Person partialDuplicate = new PersonBuilder(personInList)
                 .withName(personInList.getName().fullName.toLowerCase())
+                .withEmail("different@example.com")
+                .withAddress("Different Address 123")
                 .build();
 
-        assertCommandFailure(new AddOwnerCommand(duplicatePerson), model,
-                AddOwnerCommand.MESSAGE_DUPLICATE_PERSON);
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addPerson(partialDuplicate);
+
+        String expectedMessage = String.format(AddOwnerCommand.MESSAGE_SUCCESS, Messages.format(partialDuplicate))
+                + "\n"
+                + String.format(AddOwnerCommand.MESSAGE_PARTIAL_DUPLICATE_WARNING, "name and phone");
+
+        assertCommandSuccess(new AddOwnerCommand(partialDuplicate), model, expectedMessage, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddOwnerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOwnerCommandTest.java
@@ -62,10 +62,68 @@ public class AddOwnerCommandTest {
     }
 
     @Test
+    public void execute_partialDuplicate_showsWarning() throws Exception {
+        Person existingPerson = new PersonBuilder()
+                .withName("John Doe")
+                .withPhone("12345678")
+                .withEmail("john@example.com")
+                .withAddress("123 Clementi Road")
+                .build();
+
+        Person partialDuplicate = new PersonBuilder()
+                .withName("  john   doe ")
+                .withPhone("1234 5678")
+                .withEmail("other@example.com")
+                .withAddress("456 Jurong West Ave 1")
+                .build();
+
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded(existingPerson);
+        CommandResult commandResult = new AddOwnerCommand(partialDuplicate).execute(modelStub);
+        System.out.println(commandResult.getFeedbackToUser());
+        String expectedMessage = String.format(AddOwnerCommand.MESSAGE_SUCCESS, Messages.format(partialDuplicate))
+                + "\n"
+                + AddOwnerCommand.MESSAGE_PHONE_WARNING
+                + "\n"
+                + String.format(AddOwnerCommand.MESSAGE_PARTIAL_DUPLICATE_WARNING, "name and phone");
+
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(partialDuplicate), modelStub.personsAdded);
+    }
+
+    @Test
+    public void execute_partialDuplicateWithNonNumericPhone_showsBothWarnings() throws Exception {
+        Person existingPerson = new PersonBuilder()
+                .withName("John Doe")
+                .withPhone("65-1234-5678")
+                .withEmail("john@example.com")
+                .withAddress("123 Clementi Road")
+                .build();
+
+        Person partialDuplicate = new PersonBuilder()
+                .withName("john doe")
+                .withPhone("65-1234-5678")
+                .withEmail("other@example.com")
+                .withAddress("456 Jurong West Ave 1")
+                .build();
+
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded(existingPerson);
+        CommandResult commandResult = new AddOwnerCommand(partialDuplicate).execute(modelStub);
+
+        String expectedMessage = String.format(AddOwnerCommand.MESSAGE_SUCCESS, Messages.format(partialDuplicate))
+                + "\n"
+                + AddOwnerCommand.MESSAGE_PHONE_WARNING
+                + "\n"
+                + String.format(AddOwnerCommand.MESSAGE_PARTIAL_DUPLICATE_WARNING, "name and phone");
+
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(partialDuplicate), modelStub.personsAdded);
+    }
+
+    @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
         AddOwnerCommand addOwnerCommand = new AddOwnerCommand(validPerson);
-        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+        ModelStub modelStub = new ModelStubAcceptingPersonAdded(validPerson);
 
         assertThrows(CommandException.class,
                 AddOwnerCommand.MESSAGE_DUPLICATE_PERSON, () -> addOwnerCommand.execute(modelStub));
@@ -230,22 +288,30 @@ public class AddOwnerCommandTest {
      */
     private class ModelStubAcceptingPersonAdded extends ModelStub {
         final ArrayList<Person> personsAdded = new ArrayList<>();
+        final AddressBook addressBook = new AddressBook();
+
+        ModelStubAcceptingPersonAdded(Person... existingPersons) {
+            for (Person existingPerson : existingPersons) {
+                addressBook.addPerson(existingPerson);
+            }
+        }
 
         @Override
         public boolean hasPerson(Person person) {
             requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
+            return addressBook.hasPerson(person);
         }
 
         @Override
         public void addPerson(Person person) {
             requireNonNull(person);
             personsAdded.add(person);
+            addressBook.addPerson(person);
         }
 
         @Override
         public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
+            return addressBook;
         }
     }
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -42,9 +42,24 @@ public class UniquePersonListTest {
     @Test
     public void contains_personWithSameIdentityFieldsInList_returnsTrue() {
         uniquePersonList.add(ALICE);
-        Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Person editedAlice = new PersonBuilder(ALICE)
+                .withName("  " + ALICE.getName().fullName.toUpperCase() + " ")
+                .withPhone(addWhitespaceToPhone(ALICE.getPhone().toString()))
+                .withEmail(ALICE.getEmail().toString().toUpperCase())
+                .withAddress(" " + ALICE.getAddress().toString().toUpperCase() + " ")
+                .withTags(VALID_TAG_HUSBAND)
                 .build();
+
         assertTrue(uniquePersonList.contains(editedAlice));
+    }
+
+    private String addWhitespaceToPhone(String phone) {
+        if (phone.length() < 2) {
+            return phone;
+        }
+
+        int splitIndex = phone.length() / 2;
+        return phone.substring(0, splitIndex) + " " + phone.substring(splitIndex);
     }
 
     @Test
@@ -59,17 +74,21 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void add_personWithSameNameIgnoringCaseAndSamePhone_throwsDuplicatePersonException() {
+    public void add_personWithSameNameAndPhoneButDifferentEmailAndAddress_success() {
         uniquePersonList.add(BOB);
-        Person bobWithLowercaseName = new PersonBuilder(BOB).withName("bob choo").build();
-        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(bobWithLowercaseName));
-    }
+        Person partialDuplicateBob = new PersonBuilder(BOB)
+                .withName("bob choo")
+                .withPhone(BOB.getPhone().toString())
+                .withEmail("different@example.com")
+                .withAddress("123 Different Street")
+                .build();
 
-    @Test
-    public void add_personWithSameNameIgnoringWhitespaceAndSamePhone_throwsDuplicatePersonException() {
-        uniquePersonList.add(BOB);
-        Person bobWithExtraWhitespaceInName = new PersonBuilder(BOB).withName("  Bob   Choo ").build();
-        assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(bobWithExtraWhitespaceInName));
+        uniquePersonList.add(partialDuplicateBob);
+
+        UniquePersonList expectedUniquePersonList = new UniquePersonList();
+        expectedUniquePersonList.add(BOB);
+        expectedUniquePersonList.add(partialDuplicateBob);
+        assertEquals(expectedUniquePersonList, uniquePersonList);
     }
 
     @Test


### PR DESCRIPTION
Fixes #346 

## Summary
Improves owner duplicate detection to reduce false positives and provide better feedback.

## Changes
- Owners are duplicates only if all normalized fields match (name, phone, email, address)
- Phone comparison ignores whitespace differences
- `addowner` allows partial matches but shows warnings indicating matched fields
- Retains warning for non-numeric phone numbers

## Tests
- Updated `AddOwnerCommand` unit and integration tests
- Updated `UniquePersonListTest`
- Added tests for partial matches and phone normalization